### PR TITLE
News UI component creation

### DIFF
--- a/issue_16/.gitignore
+++ b/issue_16/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/issue_16/index.html
+++ b/issue_16/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css">
+    <script src="main.js" defer></script>
+    <title>もりけん塾 JS課題16</title>
+  </head>
+  <body>
+    <ul id="js-ul"></ul>
+  </body>
+</html>

--- a/issue_16/index.html
+++ b/issue_16/index.html
@@ -8,6 +8,6 @@
     <title>もりけん塾 JS課題16</title>
   </head>
   <body>
-    <ul id="js-ul"></ul>
+    <ul id="js-ul" class="wrapper"></ul>
   </body>
 </html>

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -1,0 +1,6 @@
+const ul = document.getElementById('js-ul');
+function createNewElements(tagName, className) {
+    const newElement = document.createElement(tagName);
+    newElement.classList.add(className);
+    return newElement;
+}

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -7,6 +7,12 @@ function createNewElements(tagName, className) {
     return newElement;
 }
 
+function displayErrorMessage() {
+    const errorMessage = createNewElements('p', 'error-message');
+    errorMessage.textContent = 'Communication failed on the server side.';
+    ul.appendChild(errorMessage);
+}
+
 async function fetchData() {
     try {
         const response = await fetch(endpoint);
@@ -36,7 +42,7 @@ async function init() {
     try {
         resultOfFetchData = await fetchData();
         if (!resultOfFetchData) {
-            return;
+            displayErrorMessage();
         }
     } catch (error) {
         console.error(error);

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -1,6 +1,46 @@
 const ul = document.getElementById('js-ul');
+const endpoint = 'https://api.json-generator.com/templates/5-2NhpTqkaV4/data?access_token=mihb6ib9irdyvy1iwbqg804flfdpm6kxdwtoum6x';
+
 function createNewElements(tagName, className) {
     const newElement = document.createElement(tagName);
     newElement.classList.add(className);
     return newElement;
 }
+
+async function fetchData() {
+    try {
+        const response = await fetch(endpoint);
+        if (!response.ok) {
+            console.error(`${response.status}:${response.statusText}`);
+        }
+        const result = await response.json();
+        return result.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+
+const renderTabs = (tabElements) => {
+    const fragment = new DocumentFragment();
+    for (const tabElement of tabElements) {
+        const tabList = createNewElements('li', 'tab-list');
+        tabList.textContent = tabElement.category;
+        fragment.appendChild(tabList);
+    }
+    ul.appendChild(fragment);
+}
+
+async function init() {
+    let resultOfFetchData;
+    try {
+        resultOfFetchData = await fetchData();
+        if (!resultOfFetchData) {
+            return;
+        }
+    } catch (error) {
+        console.error(error);
+    }
+    renderTabs(resultOfFetchData);
+}
+init();

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -27,9 +27,9 @@ async function fetchData() {
 }
 
 
-const renderTabs = (tabElements) => {
+const renderTabs = (jsonArray) => {
     const fragment = new DocumentFragment();
-    for (const tabElement of tabElements) {
+    for (const tabElement of jsonArray) {
         const tabList = createNewElements('li', 'tab-list');
         tabList.textContent = tabElement.category;
         fragment.appendChild(tabList);

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -27,11 +27,11 @@ async function fetchData() {
 }
 
 
-const renderTabs = (jsonArray) => {
+const renderTabs = (data) => {
     const fragment = new DocumentFragment();
-    for (const tabElement of jsonArray) {
+    for (const item of data) {
         const tabList = createNewElements('li', 'tab-list');
-        tabList.textContent = tabElement.category;
+        tabList.textContent = item.category;
         fragment.appendChild(tabList);
     }
     ul.appendChild(fragment);

--- a/issue_16/main.js
+++ b/issue_16/main.js
@@ -38,15 +38,15 @@ const renderTabs = (tabElements) => {
 }
 
 async function init() {
-    let resultOfFetchData;
+    let res;
     try {
-        resultOfFetchData = await fetchData();
-        if (!resultOfFetchData) {
+        res = await fetchData();
+        if (!res) {
             displayErrorMessage();
         }
     } catch (error) {
         console.error(error);
     }
-    renderTabs(resultOfFetchData);
+    renderTabs(res);
 }
 init();

--- a/issue_16/package.json
+++ b/issue_16/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "issue_16",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0"
+  }
+}

--- a/issue_16/style.css
+++ b/issue_16/style.css
@@ -1,0 +1,24 @@
+*,
+*::after,
+*::before {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+.wrapper {
+    display: flex;
+    width: 50%;
+    height: auto;
+    margin: 16px auto 0;
+    padding-bottom: 32px;
+    border: 2px solid #afafaf;
+}
+
+.tab-list {
+    list-style: none;
+    padding: 8px;
+    border-right: 2px solid #1f1f1f;
+    border-bottom: 2px solid #1f1f1f;
+    background-color: #B4E4FF;
+}

--- a/issue_16/style.css
+++ b/issue_16/style.css
@@ -9,7 +9,6 @@
 .wrapper {
     display: flex;
     width: 50%;
-    height: auto;
     margin: 16px auto 0;
     padding-bottom: 32px;
     border: 2px solid #afafaf;
@@ -20,5 +19,5 @@
     padding: 8px;
     border-right: 2px solid #1f1f1f;
     border-bottom: 2px solid #1f1f1f;
-    background-color: #B4E4FF;
+    background-color: #b4e4ff;
 }


### PR DESCRIPTION
# [issue No.16](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#16)

**issue**
これはyahooのトップページを模したUIですが、これをデータとしてどのようなものがサーバーがから返ってくれば実現できそうか、データ構造から考えて、静的なデータ(前回までのようなresolveされると返されるベタ書きのデータ)を作って、画面表示させてみてください。

仕様は

それぞれのカテゴリタブを開くことができてそれぞれのジャンルに応じた記事が4つ表示できる。(記事のタイトル名は適当)
それぞれのカテゴリにはそれぞれ固有の画像が入る(右側四角。画像は適当)
記事が3日以内のものであれば、newという新着かどうかのラベルがつく(どこの記事かは適当でいいです)
記事にはそれぞれコメントがあり、0件なら表示しない、1以上ならアイコンと共に数字が表示される
カテゴリタブは切り替えられる。面倒なら2つのカテゴリだけでよいです。その場合ニュースと経済だけにします
どのカテゴリタブを初期表示時に選んでいるかはデータとして持っている
htmlはulだけ作ってあとはcreateElementで作る
try-catchでエラー時はulの中に「ただいまサーバー側で通信がぶっ壊れています」みたいなテキストを画面内に表示すること
CSSはなしで良い。上記機能要件だけ満たしていればいい
です

## [CodeSandBox](https://githubbox.com/yoshikawa-akr/js-lessons/tree/develop/issue_16)

## Implementation concerns
https://github.com/yoshikawa-akr/js-lessons/commit/818f2e5ecebe55e228ac8f298bbdea4c9647b46e
https://github.com/yoshikawa-akr/js-lessons/commit/fe609b9d735b1bc5e3b9d202b58e287140882d3c
Even the display of tabs has been implemented.
We would like you to check if they are displayed properly when normal, or if error messages are displayed when there is an error.
The data in the initial display has not yet been implemented.